### PR TITLE
ci: switch from SLSA provenance to actions/attest with subject-path

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,9 +1,5 @@
 name: Build distribution files
 description: 'Build distribution files'
-outputs:
-  package-hashes:
-    description: "base64-encoded sha256 hashes of distribution files"
-    value: ${{ steps.package-hashes.outputs.package-hashes }}
 
 runs:
   using: composite
@@ -11,9 +7,3 @@ runs:
     - name: Build distribution files
       shell: bash
       run: poetry build
-    - name: Hash build files for provenance
-      id: package-hashes
-      shell: bash
-      working-directory: ./dist
-      run: |
-        echo "package-hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -35,13 +35,13 @@ jobs:
         id: build
 
       - name: Publish package distributions to PyPI
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
       - name: Attest build provenance
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'dist/*'

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -32,7 +32,6 @@ jobs:
           ssm_parameter_pairs: '/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN'
 
       - uses: ./.github/actions/build
-        id: build
 
       - name: Publish package distributions to PyPI
         if: ${{ format('{0}', inputs.dry_run) == 'false' }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -14,8 +14,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    outputs:
-      package-hashes: ${{ steps.build.outputs.package-hashes}}
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -41,13 +40,14 @@ jobs:
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
-  release-provenance:
-    needs: [ 'build-publish' ]
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.build-publish.outputs.package-hashes }}"
-      upload-assets: ${{ !inputs.dry_run }}
+      - name: Generate checksums file
+        env:
+          HASHES: ${{ steps.build.outputs.package-hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ inputs.dry_run == false }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -45,6 +45,7 @@ jobs:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
       - name: Generate checksums file
+        if: ${{ inputs.dry_run == false }}
         env:
           HASHES: ${{ steps.build.outputs.package-hashes }}
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,6 +6,15 @@ on:
         description: 'Is this a dry run? If so no package will be published.'
         type: boolean
         required: true
+      tag:
+        description: 'Tag of an existing draft release to upload artifacts to.'
+        type: string
+        required: false
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   build-publish:
@@ -51,3 +60,19 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['build-publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -10,11 +10,6 @@ on:
         description: 'Tag of an existing draft release to upload artifacts to.'
         type: string
         required: false
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: true
 
 jobs:
   build-publish:
@@ -60,19 +55,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['build-publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -44,15 +44,8 @@ jobs:
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
-      - name: Generate checksums file
-        if: ${{ inputs.dry_run == false }}
-        env:
-          HASHES: ${{ steps.build.outputs.package-hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ inputs.dry_run == false }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'dist/*'

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -6,10 +6,6 @@ on:
         description: 'Is this a dry run? If so no package will be published.'
         type: boolean
         required: true
-      tag:
-        description: 'Tag of an existing draft release to upload artifacts to.'
-        type: string
-        required: false
 
 jobs:
   build-publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       # Create any releases first, then create tags, and then optionally create any new PRs.
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
@@ -47,7 +47,7 @@ jobs:
 
   release-package:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       # Create any releases first, then create tags, and then optionally create any new PRs.
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
@@ -47,7 +47,7 @@ jobs:
 
   release-package:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,15 +53,8 @@ jobs:
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
-      - name: Generate checksums file
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
-        env:
-          HASHES: ${{ steps.build.outputs.package-hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'dist/*'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
-      contents: write # Contents and pull-requests are for release-please to make releases.
+      contents: write # Needed for release-please to create releases.
       pull-requests: write
       attestations: write
     steps:
@@ -38,7 +38,6 @@ jobs:
           ssm_parameter_pairs: '/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN'
 
       - uses: ./.github/actions/build
-        id: build
         if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - uses: ./.github/actions/build-docs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,6 @@ jobs:
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
       attestations: write
-    outputs:
-      release-created: ${{ steps.release.outputs.release_created }}
-      upload-tag-name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,22 +24,6 @@ jobs:
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
 
-      - name: Create release tag
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
-        env:
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
       - uses: actions/setup-python@v5
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
@@ -81,19 +65,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['release-package']
-    if: ${{ needs.release-package.outputs.release-created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,10 +11,10 @@ jobs:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
+      attestations: write
     outputs:
       release-created: ${{ steps.release.outputs.release_created }}
       upload-tag-name: ${{ steps.release.outputs.tag_name }}
-      package-hashes: ${{ steps.build.outputs.package-hashes}}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -23,6 +23,22 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
 
       - uses: actions/setup-python@v5
         if: ${{ steps.release.outputs.releases_created == 'true' }}
@@ -53,15 +69,31 @@ jobs:
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
-  release-provenance:
-    needs: [ 'release-package' ]
+      - name: Generate checksums file
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          HASHES: ${{ steps.build.outputs.package-hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['release-package']
     if: ${{ needs.release-package.outputs.release-created == 'true' }}
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
-      id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      base64-subjects: "${{ needs.release-package.outputs.package-hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ needs.release-package.outputs.upload-tag-name }}
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-package.outputs.upload-tag-name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,33 +5,67 @@ on:
     branches: [ main ]
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+    steps:
+      # Create any releases first, then create tags, and then optionally create any new PRs.
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        id: release
+        with:
+          skip-github-pull-request: true
+
+      # Need the repository content to be able to create and push a tag.
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - name: Create release tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+        if: ${{ steps.release.outputs.release_created != 'true' }}
+        id: release-prs
+        with:
+          skip-github-release: true
+
   release-package:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
-      pull-requests: write
       attestations: write
     steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
-
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
 
       - uses: actions/setup-python@v5
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           python-version: 3.9
 
       - name: Install poetry
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         name: 'Get PyPI token'
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
@@ -39,19 +73,15 @@ jobs:
 
       - uses: ./.github/actions/build
         id: build
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - uses: ./.github/actions/build-docs
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Publish package distributions to PyPI
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
       - name: Attest build provenance
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/attest@v4
         with:
           subject-path: 'dist/*'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,67 +5,33 @@ on:
     branches: [ main ]
 
 jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-    steps:
-      # Create any releases first, then create tags, and then optionally create any new PRs.
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
-        id: release
-        with:
-          skip-github-pull-request: true
-
-      # Need the repository content to be able to create and push a tag.
-      - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-
-      - name: Create release tag
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        env:
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
-        if: ${{ steps.release.outputs.release_created != 'true' }}
-        id: release-prs
-        with:
-          skip-github-release: true
-
   release-package:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
+      pull-requests: write
       attestations: write
     steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+
       - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           fetch-depth: 0 # Full history is required for proper changelog generation
 
       - uses: actions/setup-python@v5
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
           python-version: 3.9
 
       - name: Install poetry
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         name: 'Get PyPI token'
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
@@ -73,15 +39,19 @@ jobs:
 
       - uses: ./.github/actions/build
         id: build
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - uses: ./.github/actions/build-docs
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Publish package distributions to PyPI
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
       - name: Attest build provenance
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/attest@v4
         with:
           subject-path: 'dist/*'

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,10 +1,10 @@
-## Verifying SDK build provenance with the SLSA framework
+## Verifying SDK build provenance with GitHub artifact attestations
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
 
-As part of [SLSA requirements for level 3 compliance](https://slsa.dev/spec/v1.0/requirements), LaunchDarkly publishes provenance about our SDK package builds using [GitHub's generic SLSA3 provenance generator](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects) for distribution alongside our packages. These attestations are available for download from the GitHub release page for the release version under Assets > `multiple.intoto.jsonl`.
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
 
-To verify SLSA provenance attestations, we recommend using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier). Example usage for verifying a package is included below:
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
 
 <!-- x-release-please-start-version -->
 ```
@@ -13,32 +13,37 @@ VERSION=1.2.0
 ```
 <!-- x-release-please-end -->
 
-
 ```
-# Download package from PyPi
+# Download package from PyPI
 $ pip download --only-binary=:all: launchdarkly-server-sdk-otel==${VERSION}
 
-# Download provenance from Github release into same directory
-$ curl --location -O \
-  https://github.com/launchdarkly/python-server-sdk-otel/releases/download/${VERSION}/multiple.intoto.jsonl
-
-# Run slsa-verifier to verify provenance against package artifacts 
-$ slsa-verifier verify-artifact \
---provenance-path multiple.intoto.jsonl \
---source-uri github.com/launchdarkly/python-server-sdk-otel \
-launchdarkly_server_sdk_otel-${VERSION}-py3-none-any.whl
+# Verify provenance using the GitHub CLI
+$ gh attestation verify launchdarkly_server_sdk_otel-${VERSION}-py3-none-any.whl --owner launchdarkly
 ```
 
 Below is a sample of expected output.
 
 ```
-Verified signature against tlog entry index 89939519 at URL: https://rekor.sigstore.dev/api/v1/log/entries/24296fb24b8ad77abb8d2f681b007c76a4fe9f89cd9574918683ac8bc87cd6834c5baa479ae5cb98
-Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.10.0" at commit 984fc268df29918b03f51f2507146f66d8668d03
-Verifying artifact launchdarkly_server_sdk_otel-1.0.0-py3-none-any.whl: PASSED
+Loaded digest sha256:... for file://launchdarkly_server_sdk_otel-1.2.0-py3-none-any.whl
+Loaded 1 attestation from GitHub API
 
-PASSED: Verified SLSA provenance
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/python-server-sdk-otel
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/python-server-sdk-otel
+  - Signer workflow: .github/workflows/release-please.yml
 ```
 
-Alternatively, to verify the provenance manually, the SLSA framework specifies [recommendations for verifying build artifacts](https://slsa.dev/spec/v1.0/verifying-artifacts) in their documentation.
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
 
-**Note:** These instructions do not apply when building our libraries from source. 
+**Note:** These instructions do not apply when building our libraries from source.  

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Contributing
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this library.
 
-Verifying library build provenance with the SLSA framework
+Verifying library build provenance with GitHub artifact attestations
 ------------
 
-LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Contributing
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this library.
 
-Verifying library build provenance with GitHub artifact attestations
+Verifying library build provenance with the SLSA framework
 ------------
 
-LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published library packages. To learn more, see the [provenance guide](PROVENANCE.md).
 
 About LaunchDarkly
 -----------

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,6 @@
         "PROVENANCE.md"
       ],
       "include-component-in-tag": false,
-      "draft": true,
       "force-tag-creation": true
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,9 +4,13 @@
       "release-type": "python",
       "versioning": "default",
       "include-v-in-tag": false,
-      "extra-files": ["ldotel/__init__.py", "PROVENANCE.md"],
+      "extra-files": [
+        "ldotel/__init__.py",
+        "PROVENANCE.md"
+      ],
       "include-component-in-tag": false,
-      "draft": true
+      "draft": true,
+      "force-tag-creation": true
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,7 @@
         "ldotel/__init__.py",
         "PROVENANCE.md"
       ],
-      "include-component-in-tag": false,
-      "force-tag-creation": true
+      "include-component-in-tag": false
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,8 @@
       "versioning": "default",
       "include-v-in-tag": false,
       "extra-files": ["ldotel/__init__.py", "PROVENANCE.md"],
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "draft": true
     }
   }
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only and documentation changes, no application code or tests modified.

**Related issues**

Supports the org-wide migration to immutable GitHub releases. Reference implementation: `launchdarkly/ld-relay`.

**Describe the solution you've provided**

GitHub's immutable releases feature prevents modifying a release after it is published. The old SLSA provenance generator uploaded `.intoto.jsonl` files as release assets (via `upload-assets: true`), which would fail under immutable releases if the release was already published. Since this repo only uses attestation (no binary/artifact uploads to the release), draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API, not as release assets.

This PR makes the following changes:

1. **SLSA → `actions/attest@v4` with `subject-path`** (both workflows): Replaced the separate `release-provenance` job (which used `slsa-framework/slsa-github-generator` with `upload-assets: true`) with inline `actions/attest@v4` steps in the build job. Attestation uses `subject-path: 'dist/*'` to reference built distribution files directly on disk, eliminating the previous base64 encode/decode round-trip through `subject-checksums`.

2. **Removed hash-related outputs and steps**: The `package-hashes` output and "Hash build files for provenance" step are removed from the composite build action (`.github/actions/build/action.yml`), and the `package-hashes` job output is removed from workflows. No checksums file generation is needed since `subject-path` reads artifacts directly.

3. **Removed orphaned job outputs** (`release-please.yml`): The `release-created` and `upload-tag-name` outputs were only consumed by the now-removed `release-provenance` job. They have been removed to avoid dead declarations.

4. **`attestations: write` permission** (both workflows): Added to the build job to support `actions/attest@v4`.

5. **`release-please-config.json`**: Cosmetic formatting only (array elements moved to separate lines). No `draft` or `force-tag-creation` options are needed since this repo does not upload artifacts to the release.

6. **Dry-run guards on attestation** (`manual-publish.yml`): The attest step is gated on `format('{0}', inputs.dry_run) == 'false'` to safely handle the boolean/string coercion difference between `workflow_dispatch` (string) and `workflow_call` (boolean) triggers.

7. **Updated `PROVENANCE.md`**: Rewrote verification instructions to use `gh attestation verify ... --owner launchdarkly` instead of `slsa-verifier` with downloaded `.intoto.jsonl` files. Sample output follows the real `gh attestation verify` output format including policy criteria and attestation details.

### Updates since last revision

- Reverted the split release-please pattern (two-pass `skip-github-pull-request` / `skip-github-release` with inline tag creation) that was briefly added. That pattern is only needed for repos that upload artifacts to releases and require draft releases. Since this repo is attestation-only, the standard single-pass release-please is correct.

**Describe alternatives you've considered**

- An earlier revision used `subject-checksums` with a checksums file (base64-decoded from the build action output). This was simplified to `subject-path` since the built artifacts are always on disk in the same job and the base64 round-trip was inherited from the old SLSA generator pattern.
- An even earlier revision used draft releases with `force-tag-creation` and a `publish-release` job. This was removed since this repo only uses attestation (not artifact uploads), so draft releases are unnecessary.
- An earlier revision added an unused `tag` input to `manual-publish.yml` for org-wide consistency. This was removed since it had no consumers and its description referenced "draft release" which doesn't apply here.
- The verify command in `PROVENANCE.md` originally used `-R launchdarkly/python-server-sdk-otel` but was changed to `--owner launchdarkly` to match real observed output.
- The dry-run guard originally used `inputs.dry_run == false` (bare boolean comparison), but this silently fails when `workflow_call` passes a real boolean vs. `workflow_dispatch` passing a string. The `format('{0}', ...)` pattern normalizes both to a string before comparison.

**Additional context**

**Human review checklist — things worth verifying:**

- [ ] The `subject-path: 'dist/*'` glob correctly matches the output of `poetry build` (typically `*.tar.gz` and `*.whl`). If `dist/` is empty or missing at attest time, the step will fail.
- [ ] `manual-publish.yml` has `contents: read` while `release-please.yml` has `contents: write`. Verify `actions/attest@v4` does not require `contents: write` — if it does, the manual publish workflow's attestation step will fail silently.
- [ ] The dry-run guard uses `format('{0}', inputs.dry_run) == 'false'` to normalize boolean/string. Confirm this works for both `workflow_dispatch` (string `'false'`) and `workflow_call` (boolean `false`).
- [ ] In `release-please.yml`, the attest step is gated on `steps.release.outputs.releases_created` (plural). Verify this is the correct output name — release-please also emits `release_created` (singular, for the root package). Both should work for a single-package repo, but confirm they are equivalent here.
- [ ] Confirm no downstream consumers depend on the old `.intoto.jsonl` provenance file that was previously uploaded as a release asset.
- [ ] Confirm no external workflows or monitoring depend on the removed `release-created` or `upload-tag-name` job outputs from `release-please.yml`.
- [ ] The `PROVENANCE.md` sample output is representative (based on real `gh attestation verify` output from another repo), not captured from an actual run of this repo. Verify it matches reality after the first attested release.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates release/publish workflows to generate provenance via `actions/attest`, which can affect the reliability of releases and supply-chain verification if permissions or `dist/*` matching are misconfigured.
> 
> **Overview**
> Switches package provenance generation from the SLSA GitHub generator (uploaded `.intoto` release assets) to GitHub artifact attestations via `actions/attest@v4` against `dist/*`, removing the separate provenance job and any hash/checksum plumbing.
> 
> Updates both `manual-publish.yml` and `release-please.yml` to add `attestations: write`, gate publish/attest steps appropriately (including normalized `dry_run` checks), and revises `PROVENANCE.md` to document verification with `gh attestation verify` instead of downloading and validating SLSA provenance files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cba2d58fa1835d6877cf60f98bdf33a1966b620. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->