### PR TITLE
fix: conform feature_flag span event to the OTEL spec

### DIFF
--- a/ldotel/testing/test_tracing.py
+++ b/ldotel/testing/test_tracing.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from ldclient import Config, Context, LDClient
 from ldclient.evaluation import EvaluationDetail
@@ -63,7 +65,7 @@ class TestHookOptions:
         assert event.attributes['feature_flag.key'] == 'boolean'
         assert event.attributes['feature_flag.provider.name'] == 'LaunchDarkly'
         assert event.attributes['feature_flag.context.id'] == 'org:org-key'
-        assert event.attributes['feature_flag.result.variationIndex'] == '0'
+        assert event.attributes['feature_flag.result.variationIndex'] == 0
         assert 'feature_flag.result.value' not in event.attributes
         assert 'feature_flag.result.reason.inExperiment' not in event.attributes
 
@@ -81,7 +83,7 @@ class TestHookOptions:
         assert event.attributes['feature_flag.key'] == 'boolean'
         assert event.attributes['feature_flag.provider.name'] == 'LaunchDarkly'
         assert event.attributes['feature_flag.context.id'] == 'org:org-key'
-        assert event.attributes['feature_flag.result.variationIndex'] == '0'
+        assert event.attributes['feature_flag.result.variationIndex'] == 0
         assert event.attributes['feature_flag.result.value'] == 'true'
         assert 'feature_flag.result.reason.inExperiment' not in event.attributes
 
@@ -112,7 +114,7 @@ class TestHookOptions:
         assert event.attributes['feature_flag.key'] == flag_key
         assert event.attributes['feature_flag.provider.name'] == 'LaunchDarkly'
         assert event.attributes['feature_flag.context.id'] == 'org:org-key'
-        assert event.attributes['feature_flag.result.variationIndex'] == str(variation_index)
+        assert event.attributes['feature_flag.result.variationIndex'] == variation_index
         assert event.attributes['feature_flag.result.value'] == json.dumps(expected_value)
         assert 'feature_flag.result.reason.inExperiment' not in event.attributes
 
@@ -146,7 +148,7 @@ class TestHookOptions:
         assert event.attributes['feature_flag.key'] == 'boolean'
         assert event.attributes['feature_flag.provider.name'] == 'LaunchDarkly'
         assert event.attributes['feature_flag.context.id'] == 'org:org-key'
-        assert event.attributes['feature_flag.result.variationIndex'] == '0'
+        assert event.attributes['feature_flag.result.variationIndex'] == 0
         assert 'feature_flag.result.value' not in event.attributes
         assert 'feature_flag.result.reason.inExperiment' not in event.attributes
 
@@ -174,7 +176,7 @@ class TestHookOptions:
         assert middle.events[0].attributes['feature_flag.key'] == 'boolean'
         assert middle.events[0].attributes['feature_flag.provider.name'] == 'LaunchDarkly'
         assert middle.events[0].attributes['feature_flag.context.id'] == 'org:org-key'
-        assert middle.events[0].attributes['feature_flag.result.variationIndex'] == '0'
+        assert middle.events[0].attributes['feature_flag.result.variationIndex'] == 0
         assert 'feature_flag.result.value' not in middle.events[0].attributes
         assert 'feature_flag.result.reason.inExperiment' not in middle.events[0].attributes
 
@@ -182,7 +184,7 @@ class TestHookOptions:
         assert top.events[0].attributes['feature_flag.key'] == 'boolean'
         assert top.events[0].attributes['feature_flag.provider.name'] == 'LaunchDarkly'
         assert top.events[0].attributes['feature_flag.context.id'] == 'org:org-key'
-        assert top.events[0].attributes['feature_flag.result.variationIndex'] == '0'
+        assert top.events[0].attributes['feature_flag.result.variationIndex'] == 0
         assert 'feature_flag.result.value' not in top.events[0].attributes
         assert 'feature_flag.result.reason.inExperiment' not in top.events[0].attributes
 
@@ -215,8 +217,8 @@ class TestHookOptions:
         assert event.attributes['feature_flag.key'] == 'experiment-flag'
         assert event.attributes['feature_flag.provider.name'] == 'LaunchDarkly'
         assert event.attributes['feature_flag.context.id'] == 'org:org-key'
-        assert event.attributes['feature_flag.result.variationIndex'] == '1'
-        assert event.attributes['feature_flag.result.reason.inExperiment'] == 'true'
+        assert event.attributes['feature_flag.result.variationIndex'] == 1
+        assert event.attributes['feature_flag.result.reason.inExperiment'] is True
         assert 'feature_flag.result.value' not in event.attributes
 
     def test_does_not_include_variation_index_when_none(self, exporter: SpanExporter, tracer: Tracer):
@@ -251,3 +253,63 @@ class TestHookOptions:
         assert 'feature_flag.result.variationIndex' not in event.attributes
         assert 'feature_flag.result.reason.inExperiment' not in event.attributes
         assert 'feature_flag.result.value' not in event.attributes
+
+    def test_records_attributes_with_specified_types(self, exporter: SpanExporter, tracer: Tracer):
+        """
+        The OTEL spec types variationIndex as an int and inExperiment as a
+        boolean. Guard against them regressing to strings, which would break
+        consumers that match on the typed value.
+        """
+        series_context = EvaluationSeriesContext(
+            key='experiment-flag',
+            context=Context.create('org-key', 'org'),
+            default_value=False,
+            method='variation',
+        )
+        detail = EvaluationDetail(value=True, variation_index=1, reason={"inExperiment": True})
+
+        hook = Hook()
+        with tracer.start_as_current_span("test_records_attributes_with_specified_types"):
+            data = hook.before_evaluation(series_context, {})  # type: ignore
+            hook.after_evaluation(series_context, data, detail)  # type: ignore
+
+        event = exporter.get_finished_spans()[0].events[0]  # type: ignore[attr-defined]
+
+        variation_index = event.attributes['feature_flag.result.variationIndex']
+        assert isinstance(variation_index, int) and not isinstance(variation_index, bool)
+        assert variation_index == 1
+
+        in_experiment = event.attributes['feature_flag.result.reason.inExperiment']
+        assert isinstance(in_experiment, bool)
+        assert in_experiment is True
+
+    def test_records_set_id_when_environment_id_configured(self, client: LDClient, exporter: SpanExporter, tracer: Tracer):
+        client.add_hook(Hook(HookOptions(environment_id='my-environment-id')))
+        with tracer.start_as_current_span("test_records_set_id_when_environment_id_configured"):
+            client.variation('boolean', Context.create('org-key', 'org'), False)
+
+        event = exporter.get_finished_spans()[0].events[0]  # type: ignore[attr-defined]
+        assert event.attributes['feature_flag.set.id'] == 'my-environment-id'
+
+    def test_omits_set_id_when_environment_id_not_configured(self, client: LDClient, exporter: SpanExporter, tracer: Tracer):
+        client.add_hook(Hook())
+        with tracer.start_as_current_span("test_omits_set_id_when_environment_id_not_configured"):
+            client.variation('boolean', Context.create('org-key', 'org'), False)
+
+        event = exporter.get_finished_spans()[0].events[0]  # type: ignore[attr-defined]
+        assert 'feature_flag.set.id' not in event.attributes
+
+    @pytest.mark.parametrize("environment_id", ['', 0, False, []])
+    def test_ignores_and_logs_invalid_environment_id(self, environment_id, td: TestData, exporter: SpanExporter, tracer: Tracer, caplog):
+        config = Config('sdk-key', update_processor_class=td, send_events=False)
+        client = LDClient(config=config)
+
+        with caplog.at_level(logging.WARNING, logger='ldclient.otel'):
+            client.add_hook(Hook(HookOptions(environment_id=environment_id)))
+
+        with tracer.start_as_current_span("test_ignores_and_logs_invalid_environment_id"):
+            client.variation('boolean', Context.create('org-key', 'org'), False)
+
+        event = exporter.get_finished_spans()[0].events[0]  # type: ignore[attr-defined]
+        assert 'feature_flag.set.id' not in event.attributes
+        assert any(record.levelname == 'WARNING' for record in caplog.records)

--- a/ldotel/tracing.py
+++ b/ldotel/tracing.py
@@ -1,6 +1,8 @@
 import json
+import logging
 import warnings
 from dataclasses import dataclass
+from typing import Dict, Optional
 
 from ldclient.evaluation import EvaluationDetail
 from ldclient.hook import EvaluationSeriesContext
@@ -9,6 +11,9 @@ from ldclient.hook import Metadata
 from opentelemetry import trace
 from opentelemetry.context import attach, detach
 from opentelemetry.trace import Span, get_current_span, set_span_in_context
+from opentelemetry.util.types import AttributeValue
+
+log = logging.getLogger('ldclient.otel')
 
 
 @dataclass
@@ -39,11 +44,40 @@ class HookOptions:
     span events.
     """
 
+    environment_id: Optional[str] = None
+    """
+    If set, then the tracing hook will add the environment ID to span events as
+    the ``feature_flag.set.id`` attribute.
+
+    The value must be a non-empty string. Any other value is ignored, and a
+    warning is logged, which is equivalent to not specifying an environment ID
+    at all.
+    """
+
+
+def _validate_environment_id(environment_id: Optional[str]) -> Optional[str]:
+    """
+    Validate a configured environment ID, returning it only when it is a
+    non-empty string. An invalid value is logged and treated as unset.
+    """
+    if environment_id is None:
+        return None
+
+    if not isinstance(environment_id, str) or environment_id == '':
+        log.warning(
+            'The environment ID provided to the LaunchDarkly tracing hook must be a non-empty string. '
+            'The feature_flag.set.id attribute will not be added to span events.'
+        )
+        return None
+
+    return environment_id
+
 
 class Hook(LDHook):
     def __init__(self, options: HookOptions = HookOptions()):
         self.__tracer = trace.get_tracer_provider().get_tracer("launchdarkly")
         self.__options = options
+        self.__environment_id = _validate_environment_id(options.environment_id)
         if self.__options.include_variant:
             warnings.warn(
                 "The 'include_variant' option is deprecated and will be removed in a future version. "
@@ -105,17 +139,20 @@ class Hook(LDHook):
         if span is None:
             return data
 
-        attributes = {
+        attributes: Dict[str, AttributeValue] = {
             'feature_flag.context.id': series_context.context.fully_qualified_key,
             'feature_flag.key': series_context.key,
             'feature_flag.provider.name': 'LaunchDarkly',
         }
 
+        if self.__environment_id is not None:
+            attributes['feature_flag.set.id'] = self.__environment_id
+
         if detail.variation_index is not None:
-            attributes['feature_flag.result.variationIndex'] = str(detail.variation_index)
+            attributes['feature_flag.result.variationIndex'] = detail.variation_index
 
         if detail.reason.get('inExperiment'):
-            attributes['feature_flag.result.reason.inExperiment'] = 'true'
+            attributes['feature_flag.result.reason.inExperiment'] = True
 
         if self.__options.include_value or self.__options.include_variant:
             attributes['feature_flag.result.value'] = json.dumps(detail.value)


### PR DESCRIPTION
## Summary

Brings the `feature_flag` span event into conformance with the [OTEL spec](https://github.com/launchdarkly/sdk-specs/blob/main/specs/OTEL-openteletry-integration/README.md) (`OTEL` v1.0.0, ACCEPTED).

Three requirements were unmet:

| Req | Spec says | This hook did |
|---|---|---|
| 1.2.2.11 | `feature_flag.result.variationIndex` is an **int** | emitted `str(...)` |
| 1.2.2.10 | `feature_flag.result.reason.inExperiment` is a **boolean** | emitted the string `'true'` |
| 1.2.2.9 / 1.2.4 | support `feature_flag.set.id` and a configurable `environmentId` | not implemented |

The Go tracing hook (`go-server-sdk/ldotel`) already emits the specified types and supports `set.id`, so this also removes a cross-SDK inconsistency.

### Why the types matter

Consumers matching on the typed value silently never matched. Our own OTel documentation gives this collector filter:

```yaml
- 'not ((name == "feature_flag" and attributes["feature_flag.result.reason.inExperiment"] == true) or name == "exception")'
```

`== true` does not match the string `"true"`, so that documented example did not work against spans produced by this hook.

## Changes

- `variationIndex` → int, `inExperiment` → `True`
- New `HookOptions.environment_id`; when set, emits `feature_flag.set.id` (req 1.2.2.9.1.1)
- Invalid `environment_id` (non-string or empty) is ignored and logged to the `ldclient.otel` logger, equivalent to unset (reqs 1.2.4.1, 1.2.4.2)
- `attributes` annotated `Dict[str, AttributeValue]` so mypy accepts the mixed value types
- 7 new tests, including an explicit type-contract test to stop the strings regressing

## Not implemented: req 1.2.2.9.2

Sourcing the environment ID from `EvaluationSeriesContext` when it is not configured is **not implementable today**. `launchdarkly-server-sdk` 9.14.1 exposes no environment ID on either `EvaluationSeriesContext` (`key` / `context` / `default_value` / `method` only) or plugin `EnvironmentMetadata` (`sdk` / `sdk_key` / `application`). Go has `seriesContext.EnvironmentID()`; Python has no equivalent. Only the config path (1.2.2.9.1) is covered here.

## Compatibility

This changes the wire type of two attributes. Anyone filtering on the **string** forms (`"true"`, `"0"`) in a downstream OTel backend will need to match the typed values instead.

**No impact on LaunchDarkly Observability data.** Ingest stringifies span event attributes via `fmt.Sprintf("%v", v)` (`backend/clickhouse/trace_row.go` `attributesToMap`) into `String` columns, so `True` → `"true"` and `0` → `"0"` — byte-identical to the previous output.

## Testing

- `make test` — 19 passed (12 pre-existing, 7 new)
- `make lint` — `mypy`, `isort`, `pycodestyle` all clean

## Note for reviewers

Spec req **1.2.3.3** looks internally inconsistent and I did not touch it: it says the variation span must carry `feature_flag.context.key`, but its own prose cross-references 1.2.2.5, which defines `feature_flag.context.id`. Both this hook and the Go hook set `context.id`. Separately, the public observability docs state that a flag span event is identified by carrying `feature_flag.context.key`. Worth reconciling, but that's a spec decision rather than a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Brings `feature_flag` span events into OTEL spec conformance by fixing attribute types and adding optional environment ID support.
> 
> **`variationIndex`** is now emitted as an **int** (was a string), and **`inExperiment`** as a **boolean** (was `'true'`). Downstream filters matching on typed values will now work; filters that matched the old string forms need updating.
> 
> Adds optional `HookOptions.environment_id`, which emits `feature_flag.set.id` when set to a non-empty string. Invalid values are ignored with a warning on the `ldclient.otel` logger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4060136131fb55f41b2d74b611e06810cba0cc19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->